### PR TITLE
Fix bug: clear m_shINVP2List list

### DIFF
--- a/VSCapture/Class1.cs
+++ b/VSCapture/Class1.cs
@@ -984,7 +984,7 @@ namespace VSCapture
 				m_strBuilderWave.Append(',');
 				SaveWaveDataLists ("INVP2", WaveValue, 0.01);
 			}
-			m_shINVPList.Clear ();
+			m_shINVP2List.Clear ();
 
 			if(m_shPLETHList.Count != 0) WriteWaveformHeaders (DataConstants.DRI_WF_PLETH);
 			foreach (short WaveValue in m_shPLETHList)


### PR DESCRIPTION
The original code was clearing m_shINVPList (by mistake) which is already cleared.